### PR TITLE
Fix CSRF-relayed problems with Kanboard 1.2.20+

### DIFF
--- a/Controller/BacklogBoardController.php
+++ b/Controller/BacklogBoardController.php
@@ -21,6 +21,7 @@ class BacklogBoardController extends BaseController {
  * sets the board by creating swimlane and column
  */
     public function backlogSet() {
+        $this->checkCSRFParam();
         $projectId = $this->request->getIntegerParam('project_id');
 
         $this->projectUsesBacklogBoardModel->setBacklogBoard($projectId);
@@ -37,6 +38,7 @@ class BacklogBoardController extends BaseController {
  */
     
     public function backlogUnset() {
+        $this->checkCSRFParam();
         $projectId = $this->request->getIntegerParam('project_id');
 
         $this->projectUsesBacklogBoardModel->unsetBacklogBoard($projectId);

--- a/Template/board/table_container.php
+++ b/Template/board/table_container.php
@@ -27,10 +27,10 @@ $board_class = '';
                class="board-project-<?= $project['id'] ?><?= $board_class ?>"
                data-project-id="<?= $project['id'] ?>"
                data-check-interval="<?= $board_private_refresh_interval ?>"
-               data-save-url="<?= $this->url->href('BoardAjaxController', 'save', array('project_id' => $project['id'])) ?>"
-               data-reload-url="<?= $this->url->href('BoardAjaxController', 'reload', array('project_id' => $project['id'])) ?>"
-               data-check-url="<?= $this->url->href('BoardAjaxController', 'check', array('project_id' => $project['id'], 'timestamp' => time())) ?>"
-               data-task-creation-url="<?= $this->url->href('TaskCreationController', 'show', array('project_id' => $project['id'])) ?>"
+               data-save-url="<?= $this->url->href('BoardAjaxController', 'save', array('project_id' => $project['id'], 'csrf_token' => $this->app->getToken()->getReusableCSRFToken())) ?>"
+               data-reload-url="<?= $this->url->href('BoardAjaxController', 'reload', array('project_id' => $project['id'], 'csrf_token' => $this->app->getToken()->getReusableCSRFToken())) ?>"
+               data-check-url="<?= $this->url->href('BoardAjaxController', 'check', array('project_id' => $project['id'], 'csrf_token' => $this->app->getToken()->getReusableCSRFToken(), 'timestamp' => time())) ?>"
+               data-task-creation-url="<?= $this->url->href('TaskCreationController', 'show', array('project_id' => $project['id'], 'csrf_token' => $this->app->getToken()->getReusableCSRFToken())) ?>"
         >
             <?php endif ?>
 

--- a/Template/column/index.php
+++ b/Template/column/index.php
@@ -12,7 +12,7 @@
 <?php else: ?>
     <table
         class="columns-table table-striped"
-        data-save-position-url="<?= $this->url->href('ColumnController', 'move', array('project_id' => $project['id'])) ?>">
+        data-save-position-url="<?= $this->url->href('ColumnController', 'move', array('project_id' => $project['id'], 'csrf_token' => $this->app->getToken()->getReusableCSRFToken())) ?>">
         <thead>
         <tr>
             <th><?= t('Column') ?></th>

--- a/Template/swimlane/table.php
+++ b/Template/swimlane/table.php
@@ -1,6 +1,6 @@
 <table
     class="swimlanes-table table-striped table-scrolling"
-    data-save-position-url="<?= $this->url->href('SwimlaneController', 'move', array('project_id' => $project['id'])) ?>">
+    data-save-position-url="<?= $this->url->href('SwimlaneController', 'move', array('project_id' => $project['id'], 'csrf_token' => $this->app->getToken()->getReusableCSRFToken())) ?>">
     <thead>
         <tr>
             <th><?= t('Name') ?></th>


### PR DESCRIPTION
This fixes problem with moving cards on the board, that is related to CSRF-related safety checks introduced in Kanboard 1.2.20. This should fix the #24 issue.

Not being an expert in this area, I followed patterns in Kanboard code base. Things work for myself so far.